### PR TITLE
Add visible focus styles for accessibility

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -42,6 +42,20 @@
   }
 }
 
+/* Focus styles for accessibility */
+button:focus,
+input:focus,
+select:focus,
+textarea:focus,
+.icon-btn:focus,
+.chat-list-btn:focus {
+  outline: 2px solid #2684FF;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px #B2D4FF;
+  z-index: 2;
+  transition: outline 0.2s, box-shadow 0.2s;
+}
+
 body {
     font-family: Arial, sans-serif;    
     background-color: #3b3b3b;


### PR DESCRIPTION
Closes #2
This PR adds clear and visible focus styles to all interactive elements (buttons, inputs, toggles, etc.) to improve keyboard navigation and accessibility. Now, when users navigate the interface using the Tab key, each interactive element will display a distinct blue outline and box-shadow, making it easier for keyboard and assistive technology users to see which element is focused.

  /* Focus styles for accessibility */
  button:focus,
  input:focus,
  select:focus,
  textarea:focus,
  .icon-btn:focus,
  .chat-list-btn:focus {
    outline: 2px solid #2684FF;
    outline-offset: 2px;
    box-shadow: 0 0 0 2px #B2D4FF;
    z-index: 2;
    transition: outline 0.2s, box-shadow 0.2s;
  }

**Testing**
- Verified that all interactive elements now show a visible focus indicator when tabbing through the UI in both light and dark modes.